### PR TITLE
fix: adjust scroll sensitivity during image zoom

### DIFF
--- a/lib/photo_viewer.dart
+++ b/lib/photo_viewer.dart
@@ -725,6 +725,7 @@ class _InteractivePhotoPageState extends State<InteractivePhotoPage> {
           transformationController: widget.transformationController,
           minScale: widget.minScale,
           maxScale: widget.maxScale,
+          scaleFactor: 100,
           child: Center(
             child: widget.useHero
                 ? Hero(


### PR DESCRIPTION
Fixed an issue where scrolling a zoomed image would cause the image to move much more than the actual pointer movement.

- The `scaleFactor` parameter controls how much the image moves in response to drag operations
- Reducing the value to 100 makes the ratio between pointer movement and image movement closer to 1:1