### PR TITLE
feat: expose some GestureDetector properties in PhotoViewerImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A versatile Flutter library for displaying and interacting with images in your a
 - Multiple image viewing with pagination
 - Custom overlay support
 - Hero animation support
+- Support for asset, network, and file images
 
 ## Installation
 
@@ -58,7 +59,20 @@ PhotoViewerMultipleImage(
 
 ### Direct Display Function
 
-For more control, use the `showPhotoViewer` function:
+
+`PhotoViewerImage` also supports the same gesture callbacks as PhotoViewerImage:
+
+```dart
+PhotoViewerImage(
+  imageUrls: imageList,
+  index: 0,
+  id: 'gallery',
+  onLongPress: () => print('Long pressed!'),
+  onDoubleTap: () => print('Double tapped!'),
+)
+```
+
+The `PhotoViewerImage` widget handles file images, network images, and asset images, and also exposes properties such as long press and double tap. However, if you want more detailed customization, please refer to the `PhotoViewerImage` implementation and call the `showPhotoViewer` function directly.
 
 ```dart
 showPhotoViewer(
@@ -178,6 +192,7 @@ Check out the example project in the `example` folder for complete implementatio
 - Gallery with thumbnails
 - Comment overlay
 - Manga/book reader
+- Custom gesture handling examples
 
 ## License
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -99,6 +99,19 @@ class HomePage extends StatelessWidget {
               );
             },
           ),
+          ListTile(
+            title: const Text('PhotoViewerImage properties Sample'),
+            subtitle:
+                const Text('PhotoViewerImage with custom gesture handling'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (context) => const CustomGestureSamplePage(),
+                ),
+              );
+            },
+          ),
         ],
       ),
     );
@@ -1228,6 +1241,113 @@ class NetworkImageSamplePage extends StatelessWidget {
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+class CustomGestureSamplePage extends StatelessWidget {
+  const CustomGestureSamplePage({super.key});
+
+  static const List<String> images = [
+    'assets/feed_image.jpg',
+    'assets/feed_image2.jpg',
+    'assets/feed_image3.jpg',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Custom Gesture Sample'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Custom Gesture Examples:',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+
+            // Example 1: Long press to show snackbar
+            const Text('1. Long press to show message:'),
+            const SizedBox(height: 8),
+            Card(
+              clipBehavior: Clip.antiAlias,
+              child: PhotoViewerImage(
+                imageUrl: images[0],
+                onLongPress: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Long pressed on image!'),
+                      duration: Duration(seconds: 2),
+                    ),
+                  );
+                },
+              ),
+            ),
+
+            const SizedBox(height: 24),
+
+            // Example 2: Double tap custom behavior
+            const Text('2. Double tap to show dialog:'),
+            const SizedBox(height: 8),
+            Card(
+              clipBehavior: Clip.antiAlias,
+              child: PhotoViewerImage(
+                imageUrl: images[1],
+                onDoubleTap: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: const Text('Double Tap Detected'),
+                        content: const Text('You double tapped on the image!'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: const Text('OK'),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+
+            const SizedBox(height: 24),
+
+            // Example 3: Both long press and double tap
+            const Text('3. Both long press and double tap:'),
+            const SizedBox(height: 8),
+            Card(
+              clipBehavior: Clip.antiAlias,
+              child: PhotoViewerImage(
+                imageUrl: images[2],
+                onLongPress: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Long press detected!'),
+                      duration: Duration(seconds: 1),
+                    ),
+                  );
+                },
+                onDoubleTap: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Double tap detected!'),
+                      duration: Duration(seconds: 1),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/photo_viewer.dart
+++ b/lib/photo_viewer.dart
@@ -320,6 +320,8 @@ class PhotoViewerImage extends StatelessWidget {
     this.fit = BoxFit.cover,
     this.placeholder,
     this.errorWidget,
+    this.onLongPress,
+    this.onDoubleTap,
     super.key,
   });
 
@@ -332,6 +334,9 @@ class PhotoViewerImage extends StatelessWidget {
   final BoxFit fit;
   final Widget Function(BuildContext, String)? placeholder;
   final Widget Function(BuildContext, String, dynamic)? errorWidget;
+
+  final VoidCallback? onLongPress;
+  final VoidCallback? onDoubleTap;
 
   @override
   Widget build(BuildContext context) {
@@ -347,6 +352,8 @@ class PhotoViewerImage extends StatelessWidget {
       fit: fit,
       placeholder: placeholder,
       errorWidget: errorWidget,
+      onLongPress: onLongPress,
+      onDoubleTap: onDoubleTap,
     );
   }
 }
@@ -367,6 +374,8 @@ class PhotoViewerMultipleImage extends StatelessWidget {
     this.fit = BoxFit.cover,
     this.placeholder,
     this.errorWidget,
+    this.onLongPress,
+    this.onDoubleTap,
     super.key,
   });
 
@@ -384,42 +393,52 @@ class PhotoViewerMultipleImage extends StatelessWidget {
   final Widget Function(BuildContext, String)? placeholder;
   final Widget Function(BuildContext, String, dynamic)? errorWidget;
 
+  final VoidCallback? onLongPress;
+
+  final VoidCallback? onDoubleTap;
+
   String _heroTag(int index) =>
       'photo_viewer_${id}_${index}_${imageUrls[index]}';
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        showPhotoViewer(
-          context: context,
-          builders: imageUrls.map<WidgetBuilder>((url) {
-            return (BuildContext context) => _buildImageFromUrl(
-                  url,
-                  fit: fit,
-                  placeholder: placeholder,
-                  errorWidget: errorWidget,
-                );
-          }).toList(),
-          heroTagBuilder: _heroTag,
-          initialPage: index,
-          overlayBuilder: overlayBuilder,
-          minScale: minScale,
-          maxScale: maxScale,
-          showDefaultCloseButton: showDefaultCloseButton,
-          onPageChanged: onPageChanged,
-          onJumpToPage: onJumpToPage,
-        );
-      },
-      child: Hero(
-        tag: _heroTag(index),
-        child: _buildImageFromUrl(
-          imageUrls[index],
-          fit: fit,
-          placeholder: placeholder,
-          errorWidget: errorWidget,
-        ),
+    void defaultOnTap() {
+      showPhotoViewer(
+        context: context,
+        builders: imageUrls.map<WidgetBuilder>((url) {
+          return (BuildContext context) => _buildImageFromUrl(
+                url,
+                fit: fit,
+                placeholder: placeholder,
+                errorWidget: errorWidget,
+              );
+        }).toList(),
+        heroTagBuilder: _heroTag,
+        initialPage: index,
+        overlayBuilder: overlayBuilder,
+        minScale: minScale,
+        maxScale: maxScale,
+        showDefaultCloseButton: showDefaultCloseButton,
+        onPageChanged: onPageChanged,
+        onJumpToPage: onJumpToPage,
+      );
+    }
+
+    final child = Hero(
+      tag: _heroTag(index),
+      child: _buildImageFromUrl(
+        imageUrls[index],
+        fit: fit,
+        placeholder: placeholder,
+        errorWidget: errorWidget,
       ),
+    );
+
+    return GestureDetector(
+      onTap: defaultOnTap,
+      onLongPress: onLongPress,
+      onDoubleTap: onDoubleTap,
+      child: child,
     );
   }
 }


### PR DESCRIPTION
Exposed some `GestureDetector` properties in `PhotoViewerImage`. This enables specify long-tap and double-tap. An example has been added to `CustomGestureSamplePage`.

This change won't affect the viewer itself.