### PR TITLE
Improve: Resolve conflict between viewer zoom and horizontal swipes

### DIFF
--- a/lib/photo_viewer.dart
+++ b/lib/photo_viewer.dart
@@ -706,6 +706,7 @@ class _InteractivePhotoPageState extends State<InteractivePhotoPage> {
   bool isDismissEnabled = true;
   bool isDismissed = false;
   bool isZoomed = false;
+  int _pointerCount = 0;
 
   @override
   void initState() {
@@ -786,15 +787,31 @@ class _InteractivePhotoPageState extends State<InteractivePhotoPage> {
   @override
   Widget build(BuildContext context) {
     return Listener(
-      onPointerUp: (_) => changeVisibility(),
+      onPointerUp: (_) {
+        changeVisibility();
+        _pointerCount--;
+      },
+      onPointerDown: (_) {
+        _pointerCount++;
+        if (_pointerCount >= 2) {
+          widget.onScaleChanged?.call(widget.maxScale);
+        }
+      },
+      onPointerCancel: (_) {
+        _pointerCount--;
+      },
       child: GestureDetector(
         onDoubleTap: doubleTap,
         onDoubleTapDown: (details) {
           doubleTapPosition = details.localPosition;
         },
         child: InteractiveViewer(
-          onInteractionStart: (_) =>
-              widget.controlsVisibilityController.reverse(),
+          onInteractionStart: (details) {
+            widget.controlsVisibilityController.reverse();
+            if (details.pointerCount >= 2) {
+              widget.onScaleChanged?.call(widget.maxScale);
+            }
+          },
           onInteractionEnd: (_) {
             onScaleChanged(widget.transformationController.value.row0.x);
           },


### PR DESCRIPTION
close #2

This change improves zoom responsiveness in the viewer, which previously felt unresponsive due to conflicts with horizontal swipes.

When the user performs a pinch gesture, it also includes a horizontal component, making it difficult to resolve the conflict with page swipes. However, I noticed that `Listener.onPointerDown` is prioritized over PageView’s swipe handling, so I decided to use this to forcibly trigger onScaleChanged.

`PhotoViewerScreenState` now keeps track of the number of fingers touching the screen. If two or more fingers are detected, zooming takes priority over swipe gestures.
