### PR TITLE
fix: resolve animation glitch after app returns from background

### DIFF
--- a/lib/photo_viewer.dart
+++ b/lib/photo_viewer.dart
@@ -45,6 +45,8 @@ Widget _buildImageFromUrl(
       fit: fit,
       width: width,
       height: height,
+      fadeInDuration: Duration.zero,
+      fadeOutDuration: Duration.zero,
       placeholder: placeholder ??
           (context, url) => const Center(child: CircularProgressIndicator()),
       errorWidget: errorWidget ??
@@ -56,6 +58,7 @@ Widget _buildImageFromUrl(
       fit: fit,
       width: width,
       height: height,
+      gaplessPlayback: true,
     );
   } else {
     return Image.asset(
@@ -63,6 +66,7 @@ Widget _buildImageFromUrl(
       fit: fit,
       width: width,
       height: height,
+      gaplessPlayback: true,
     );
   }
 }


### PR DESCRIPTION
## Summary
- Set `fadeInDuration`/`fadeOutDuration` to `Duration.zero` on `CachedNetworkImage` to eliminate placeholder flash when reloading images after returning from background
- Add `gaplessPlayback: true` to `Image.file` / `Image.asset` to retain the previous frame during image re-decoding

## Why
When the app returns from the background, the in-memory image cache may be cleared. If the user taps an image preview in this state, the Hero animation captures the placeholder (`CircularProgressIndicator`) instead of the actual image, causing the animation to break.

Closes #15